### PR TITLE
Support for Dokka 0.10.0

### DIFF
--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -48,7 +48,7 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
 
     if (plugins.hasPlugin('kotlin-android')) {
       def dokkaOutput = "${project.docsDir}/dokka"
-      project.plugins.apply('org.jetbrains.dokka-android')
+      project.plugins.apply('org.jetbrains.dokka')
       project.dokka {
         outputFormat 'html'
         outputDirectory dokkaOutput


### PR DESCRIPTION
[Dokka 0.10.0](https://github.com/Kotlin/dokka/releases/tag/0.10.0) merges the android plugin into the main plugin, so this plugin fails when it tries to apply the `dokka-android` plugin.

This change will cause the regular dokka plugin to be applied to `kotlin-android` projects instead of the obsolete `dokka-android` one, which means it **breaks support for dokka versions pre-0.10.0**.

This fixes #69.